### PR TITLE
Update libsemanage

### DIFF
--- a/4_install_misc.sh
+++ b/4_install_misc.sh
@@ -1,5 +1,5 @@
 
 dnf install -y pyOpenSSL python-cryptography python-lxml java-1.8.0-openjdk-headless patch 
-dnf install -y iproute python3-dbus python3-PyYAML libsemanage-python yum-utils python3-docker
+dnf install -y iproute python3-dbus python3-PyYAML python3-libsemanage yum-utils python3-docker
 
 


### PR DESCRIPTION
On Fedora 34 the package name was changed from `libsemanage-python` to `python3-libsemanage`.
I'm not sure if we need a conditional statement according to the distro version.

Signed-off-by: Lucas Zampieri <lzampier@redhat.com>